### PR TITLE
All non axe-core functionalities moved into pytest-axe package

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 CHANGELOG
 ^^^^^^^^^^^^^^
 
+version 2.0.0
+**************
+- All functionalities that are not part of axe-core have been moved into a separate package, ``pytest-axe``. This includes:
+  - ``run_axe`` helper method
+  - ``get_rules`` Axe class method
+  - ``run`` Axe class method
+  - ``impact_included`` Axe class method
+  - ``analyze`` Axe class method.
+  
+The purpose of this change is to separate implementations that are specific to the Mozilla Firefox Test Engineering team, and leave the base ``axe-selenium-python`` package for a more broad use case. This package was modeled off of Deque's Java package, axe-selenium-java, and will now more closely mirror it.
+
+All functionalities can still be utilized when using ``axe-selenium-python`` in conjunction with ``pytest-axe``.
+
 version 1.2.3
 **************
 - Added the analyze method to the Axe class. This method runs accessibility checks, and writes the JSON results to file based on the page URL and the timestamp.

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,6 @@ axe-selenium-python integrates aXe and selenium to enable automated web accessib
 .. image:: https://img.shields.io/pypi/wheel/axe-selenium-python.svg?style=for-the-badge
    :target: https://pypi.org/project/axe-selenium-python/
    :alt: wheel
-.. .. image:: https://img.shields.io/travis/kimberlythegeek/axe-selenium-python.svg?style=for-the-badge
-..    :target: https://travis-ci.org/kimberlythegeek/axe-selenium-python/
-..    :alt: Travis
 .. image:: https://img.shields.io/github/issues-raw/kimberlythegeek/axe-selenium-python.svg?style=for-the-badge
    :target: https://github.com/kimberlythegeek/axe-selenium-python/issues
    :alt: Issues
@@ -27,13 +24,9 @@ Requirements
 
 You will need the following prerequisites in order to use axe-selenium-python:
 
+- selenium >= 3.0.0
 - Python 2.7 or 3.6
-- pytest-selenium >= 3.0.0
 - `geckodriver <https://github.com/mozilla/geckodriver/releases>`_ downloaded and `added to your PATH <https://stackoverflow.com/questions/40208051/selenium-using-python-geckodriver-executable-needs-to-be-in-path#answer-40208762>`_
-
-Optional
-^^^^^^^^
-- tox
 
 Installation
 ------------
@@ -44,48 +37,33 @@ To install axe-selenium-python:
 
   $ pip install axe-selenium-python
 
-To install pytest-axe:
-
-.. code-block:: bash
-
-  $ pip install pytest-axe
 
 Usage
 ------
-``test_accessibility.py``
 
 .. code-block:: python
 
-   import pytest
+ import pytest
+  from selenium import webdriver
+  from axe_selenium_python import Axe
 
-    @pytest.mark.nondestructive
-    def test_header_accessibility(axe):
-        violations = axe.run('header', None, 'critical')
-        assert len(violations) == 0, axe.report(violations)
+  def test_google():
+      driver = webdriver.Firefox()
+      driver.get("http://www.google.com")
+      axe = Axe(driver)
+      # Inject axe-core javascript into page.
+      axe.inject()
+      # Run axe accessibility checks.
+      results = axe.execute()
+      # Write results to file
+      axe.write_results('a11y.json', results)
+      driver.close()
+      # Assert no violations are found
+      assert len(results["violations"]) == 0, axe.report(results["violations"])
 
+The method ``axe.execute()`` accepts two parameters: ``context`` and ``options``.
 
-
-The above example runs aXe against only the content within the *<header>* tag, and filters for violations labeled ``critical``.
-
-The method ``axe.run()`` accepts three parameters: ``context``, ``options``, and
-``impact``.
-
-For more information on ``context`` and ``options``, view the `aXe
-documentation here <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#parameters-axerun>`_.
-
-The third parameter, ``impact``, allows you to filter violations by their impact
-level. The options are ``'critical'``, ``'serious'`` and ``'minor'``, with the
-default value set to ``None``.
-
-This will filter violations for the impact level specified, and **all violations with a higher impact level**.
-
-To run the above test you will need to specify the browser instance to be invoked, and the **base_url**.
-
-.. code-block:: bash
-
-  $ pytest --base-url http://www.mozilla.com --driver Firefox test_accessibility.py
-
-
+For more information on ``context`` and ``options``, view the `aXe documentation here <https://github.com/dequelabs/axe-core/blob/master/doc/API.md#parameters-axerun>`_.
 
 Resources
 ---------

--- a/axe_selenium_python/axe.py
+++ b/axe_selenium_python/axe.py
@@ -59,16 +59,16 @@ class Axe(object):
         """
         string = ''
         string += 'Found ' + str(len(violations)) + ' accessibility violations:'
-        for violation, rule in violations.items():
-            string += '\n\n\nRule Violated:\n' + rule['id'] + ' - ' + rule['description'] + \
-                '\n\tURL: ' + rule['helpUrl'] + \
-                '\n\tImpact Level: ' + rule['impact'] + \
+        for violation in violations:
+            string += '\n\n\nRule Violated:\n' + violation['id'] + ' - ' + violation['description'] + \
+                '\n\tURL: ' + violation['helpUrl'] + \
+                '\n\tImpact Level: ' + violation['impact'] + \
                 '\n\tTags:'
-            for tag in rule['tags']:
+            for tag in violation['tags']:
                 string += ' ' + tag
             string += '\n\tElements Affected:'
             i = 1
-            for node in rule['nodes']:
+            for node in violation['nodes']:
                 for target in node['target']:
                     string += '\n\t' + str(i) + ') Target: ' + target
                     i += 1

--- a/axe_selenium_python/tests/conftest.py
+++ b/axe_selenium_python/tests/conftest.py
@@ -15,7 +15,7 @@ _DEFAULT_SCRIPT = os.path.join(os.path.dirname(__file__), 'src', 'axe.min.js')
 
 @pytest.fixture
 def script_url():
-    """Return a script URL"""
+    """Return a script URL."""
     return _DEFAULT_SCRIPT
 
 

--- a/axe_selenium_python/tests/requirements/tests.txt
+++ b/axe_selenium_python/tests/requirements/tests.txt
@@ -1,4 +1,5 @@
 pytest==3.5.0
+selenium==3.11.0
 pytest-selenium==1.12.0
 pytest-html==1.16.1
 pytest_base_url==1.4.1

--- a/axe_selenium_python/tests/requirements/tests.txt
+++ b/axe_selenium_python/tests/requirements/tests.txt
@@ -1,4 +1,4 @@
-pytest==3.4.2
+pytest==3.5.0
 pytest-selenium==1.12.0
 pytest-html==1.16.1
 pytest_base_url==1.4.1

--- a/axe_selenium_python/tests/test_axe.py
+++ b/axe_selenium_python/tests/test_axe.py
@@ -7,14 +7,6 @@ import pytest
 
 
 @pytest.mark.nondestructive
-def test_get_rules(axe):
-    """Assert number of rule tests matches number of available rules."""
-    axe.inject()
-    rules = axe.get_rules()
-    assert len(rules) == 58, len(rules)
-
-
-@pytest.mark.nondestructive
 def test_execute(axe):
     """Run axe against base_url and verify JSON output."""
     axe.inject()
@@ -23,17 +15,11 @@ def test_execute(axe):
 
 
 @pytest.mark.nondestructive
-def test_run(base_url, axe):
-    """Assert that run method returns results."""
-    violations = axe.run()
-    assert violations is not None
-
-
-@pytest.mark.nondestructive
 def test_report(axe):
     """Test that report exists."""
-    violations = axe.run()
-
+    axe.inject()
+    results = axe.execute()
+    violations = results["violations"]
     report = axe.report(violations)
     assert report is not None, report
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 
 
 setup(name='axe-selenium-python',
-      version='1.2.4',
+      version='1.2.8',
       description='Python library to integrate axe and selenium for web \
                 accessibility testing.',
       long_description=readme(),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 
 
 setup(name='axe-selenium-python',
-      version='1.2.8',
+      version='2.0.0',
       description='Python library to integrate axe and selenium for web \
                 accessibility testing.',
       long_description=readme(),


### PR DESCRIPTION
- All functionalities that are not part of axe-core have been moved into a separate package, ``pytest-axe``. This includes:
  - ``run_axe`` helper method
  - ``get_rules`` Axe class method
  - ``run`` Axe class method
  - ``impact_included`` Axe class method
  - ``analyze`` Axe class method.
  
The purpose of this change is to separate implementations that are specific to the Mozilla Firefox Test Engineering team, and leave the base ``axe-selenium-python`` package for a more broad use case. This package was modeled off of Deque's Java package, axe-selenium-java, and will now more closely mirror it.